### PR TITLE
chore: optimize the dependency installation logic

### DIFF
--- a/status.sh
+++ b/status.sh
@@ -220,7 +220,7 @@ Installation_dependency() {
         yum -y install python3
         ln -s /usr/bin/python3 /usr/bin/python
       fi
-    elif [ ${release} == "debian" ] || [${release} == "ubuntu"]; then
+    else
       if [ "${python_status}" -eq 0 ]; then
         apt-get -y update
         apt-get -y install python3

--- a/status.sh
+++ b/status.sh
@@ -197,7 +197,8 @@ Installation_dependency() {
     if [[ ${release} == "centos" ]]; then
       yum -y update
       if [ ${python_status} -eq 0 ]; then
-        yum -y install python unzip vim make
+        yum -y install python3 unzip vim make
+        ln -s /usr/bin/python3 /usr/bin/python
         yum -y groupinstall "Development Tools"
       elif [ ${python_status} -eq 1 ]; then
         yum -y install unzip vim make
@@ -206,7 +207,8 @@ Installation_dependency() {
     else
       apt-get update -y
       if [ ${python_status} -eq 0 ]; then
-        apt-get -y install python unzip vim build-essential
+        apt-get -y install python3 unzip vim build-essential
+        ln -s /usr/bin/python3 /usr/bin/python
       elif [ ${python_status} -eq 1 ]; then
         apt-get -y install unzip vim build-essential
       fi
@@ -215,12 +217,14 @@ Installation_dependency() {
     if [ ${release} == "centos" ]; then
       if [ "${python_status}" -eq 0 ]; then
         yum -y update
-        yum -y install python
+        yum -y install python3
+        ln -s /usr/bin/python3 /usr/bin/python
       fi
     elif [ ${release} == "debian" ] || [${release} == "ubuntu"]; then
       if [ "${python_status}" -eq 0 ]; then
         apt-get -y update
-        apt-get -y install python
+        apt-get -y install python3
+        ln -s /usr/bin/python3 /usr/bin/python
       fi
     fi
   fi

--- a/status.sh
+++ b/status.sh
@@ -185,12 +185,11 @@ Service_Server_Status_client() {
 }
 Installation_dependency() {
   mode=$1
-  [[ -z ${mode} ]] && mode="server"
-  if python --help >/dev/null 2>&1; then
+  if python3 --help >/dev/null 2>&1; then
+    ln -s /usr/bin/python3 /usr/bin/python 
     python_status=1
-  elif python3 --help >/dev/null 2>&1; then
-    ln -s /usr/bin/python3 /usr/bin/python
-    python_status=2
+  elif python --help >/dev/null 2>&1; then
+    python_status=1
   else
     python_status=0
   fi
@@ -200,7 +199,7 @@ Installation_dependency() {
       if [ ${python_status} -eq 0 ]; then
         yum -y install python unzip vim make
         yum -y groupinstall "Development Tools"
-      else
+      elif [ ${python_status} -eq 1 ]; then
         yum -y install unzip vim make
         yum -y groupinstall "Development Tools"
       fi
@@ -208,17 +207,17 @@ Installation_dependency() {
       apt-get update -y
       if [ ${python_status} -eq 0 ]; then
         apt-get -y install python unzip vim build-essential
-      else
+      elif [ ${python_status} -eq 1 ]; then
         apt-get -y install unzip vim build-essential
       fi
     fi
-  else
+  elif [[ ${mode} == "client" ]]; then
     if [ ${release} == "centos" ]; then
       if [ "${python_status}" -eq 0 ]; then
         yum -y update
         yum -y install python
       fi
-    else
+    elif [ ${release} == "debian" ] || [${release} == "ubuntu"]; then
       if [ "${python_status}" -eq 0 ]; then
         apt-get -y update
         apt-get -y install python


### PR DESCRIPTION
Fix the situation that Python2 still needs to be installed even if Python3 is already installed on the system.